### PR TITLE
Use GET instead of POST if no payload

### DIFF
--- a/keycloak/core/asynchronous/authentication.py
+++ b/keycloak/core/asynchronous/authentication.py
@@ -154,7 +154,7 @@ class AsyncAuthenticationMixin:
         headers = auth_header(access_token)
         log.debug("Retrieving user info from server")
         async with httpx.AsyncClient() as client:
-            response = await client.post(
+            response = await client.get(
                 config.openid.userinfo_endpoint, headers=headers
             )
             log.debug("User info retrieved successfully")

--- a/keycloak/core/authentication.py
+++ b/keycloak/core/authentication.py
@@ -130,7 +130,7 @@ class AuthenticationMixin:
         access_token = access_token or self.access_token  # type: ignore
         headers = auth_header(access_token)
         log.debug("Retrieving user info from server")
-        response = httpx.post(config.openid.userinfo_endpoint, headers=headers)
+        response = httpx.get(config.openid.userinfo_endpoint, headers=headers)
         response.raise_for_status()
         log.debug("User info retrieved successfully")
         return response.json()


### PR DESCRIPTION
Some HTTP servers serving Keycloak endpoint fail with `500 server error` when receiving POST requests with empty request body (no payload). This keycloak-client library makes such calls to the UserInfo endpoint, passing the bearer token in the request header (`Authorization: Bearer <token>`) rather than in payload (`access_token=<token`). Changing these POST requests to GET fixes the problem.